### PR TITLE
RETCO 3410

### DIFF
--- a/src/components/redo-checkout-buttons.tsx
+++ b/src/components/redo-checkout-buttons.tsx
@@ -63,6 +63,10 @@ const applyButtonVariables = ({
   cart: CartReturn,
   ui: CheckoutButtonUIResponse
 }): CheckoutButtonUIResponse | null => {
+  if(!redoCoverageClient.eligible || !redoCoverageClient.price) {
+    return null;
+  }
+
   let currencyCode: CurrencyCode = cart.cost.totalAmount.currencyCode;
   if(currencyCode === 'XXX') {
     currencyCode = 'USD';
@@ -112,7 +116,7 @@ const RedoCheckoutButtons = (props: {
 
   useEffect(() => {
     (async () => {
-      if(!redoCoverageClient.storeId || !cart) {
+      if(!redoCoverageClient.eligible || !cart || !redoCoverageClient.storeId) {
         return;
       }
 
@@ -121,7 +125,7 @@ const RedoCheckoutButtons = (props: {
         setCheckoutButtonsUI(buttons);
       }
     })();
-  }, [cart, redoCoverageClient.price, redoCoverageClient.storeId]);
+  }, [cart, redoCoverageClient.eligible, redoCoverageClient.price, redoCoverageClient.storeId]);
 
   const wrapperClickHandler = async (e: MouseEvent) => {
     let clickedElement = e.target as HTMLElement;

--- a/src/providers/redo-coverage-client.tsx
+++ b/src/providers/redo-coverage-client.tsx
@@ -36,7 +36,7 @@ const RedoProvider = ({
   }
 
   useEffect(() => {
-    if(!cart) {
+    if(!cart || !storeId) {
       return;
     }
 
@@ -106,7 +106,7 @@ const RedoProvider = ({
         });
         return;
       }
-      
+
       let json = await res.json();
 
       setLoading(false);
@@ -117,7 +117,7 @@ const RedoProvider = ({
 
       setCartInfoToEnable(json.coverageProducts[0].cartInfoToEnable);
     })
-  }, [cart]);
+  }, [cart, storeId]);
   
   const contextVal: RedoContextValue = {
     enabled: true,
@@ -186,13 +186,16 @@ const useRedoCoverageClient = (): RedoCoverageClient => {
     get loading() {
       return redoContext.loading;
     },
+    get eligible() {
+      return !this.loading && !!this.price && !!this.cartProduct;
+    },
     get enabled() {
       return redoContext.enabled;
     },
     get price() {
       let priceToEnable = redoContext.cartInfoToEnable?.selectedVariant?.price?.amount;
       if(!priceToEnable || Number(priceToEnable).toString() === 'NaN') {
-        return 0;
+        return undefined;
       }
 
       return Number(priceToEnable);

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,7 +12,8 @@ interface RedoCoverageClient {
   disable(): Promise<boolean>;
   get loading(): boolean;
   get enabled(): boolean;
-  get price(): number;
+  get eligible(): boolean;
+  get price(): number | undefined;
   get storeId(): string | undefined;
   get cart(): CartReturn | undefined;
   get cartProduct(): CartProductVariantFragment | undefined;


### PR DESCRIPTION
Fleo was having issues with the buttons not showing up. It ended up being they were passing in a bad value for the cart which our backend was correctly reporting as a 400, but we weren't logging that information anywhere.

Also fixes issue where currency is unknown or loading and the number format shows XXX 23.49. In those cases we'll fall back to USD and show $23.49.

Also, as backup backup, if somehow we do get a NaN response for coverage price, just say 0. Updating docs...