### PR TITLE
Npmignore dont include dist folder

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,2 @@
+node_modules/
+.DS_Store


### PR DESCRIPTION
If the npmignore doesn't exist, it uses gitignore file, which includes the dist folder, so root exports have been broken.

People have been using @redotech/redo-hydrogen/src 😅 