### PR TITLE
Remove unused prop

### DIFF
--- a/src/components/redo-checkout-buttons.tsx
+++ b/src/components/redo-checkout-buttons.tsx
@@ -102,7 +102,6 @@ const findAncestor = (
 };
 
 const RedoCheckoutButtons = (props: {
-  cart: CartReturn | CartWithActionsDocs | OptimisticCart;
   children?: ReactNode;
   onClick?: (enabled: boolean) => void;
 }) => {


### PR DESCRIPTION
CheckoutButtons used to require a cart prop until they were passed through provider. The prop was never removed after getting the val from the provider