### PR TITLE
Make hydrogen version more flexible, re-add react dom peer dep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,8 +27,8 @@
       "peerDependencies": {
         "@remix-run/react": "^2.15.2",
         "@shopify/hydrogen": "^2024.10.1",
-        "@shopify/hydrogen-react": "^2024.10.1",
-        "react-dom": "^18.3.1"
+        "@shopify/hydrogen-react": ">=2024.3.1",
+        "react-dom": "~18.3.1"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -2636,7 +2636,6 @@
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.0.4.tgz",
       "integrity": "sha512-4fSQ8vWFkg+TGhePfUzVmat3eC14TXYSsiiDSLI0dVLsrm9gZFABjPy/Qu6TKgl1tq1Bu1yDsuQgY3A3DOjCcg==",
       "dev": true,
-      "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
   "peerDependencies": {
     "@remix-run/react": "^2.15.2",
     "@shopify/hydrogen": "^2024.10.1",
-    "@shopify/hydrogen-react": "^2024.10.1"
+    "@shopify/hydrogen-react": ">=2024.3.1",
+    "react-dom": "~18.3.1"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^28.0.2",
@@ -28,8 +29,10 @@
     "@rollup/plugin-typescript": "^12.1.2",
     "@svgr/rollup": "^8.1.0",
     "@types/react": "^19.0.8",
+    "@types/react-dom": "^19.0.4",
     "nodemon": "^3.1.9",
     "react": "^18.3.1",
+    "react-dom": "^18.3.1",
     "rollup": "^4.32.1",
     "rollup-plugin-dts": "^6.1.1",
     "rollup-plugin-peer-deps-external": "^2.2.4",


### PR DESCRIPTION
It looks like the react-dom peer dep got removed in 1.3.0 (check file history) but we still need it.

Also we've had merchants using it as far back as Hydrogen 2024.3.0 and as far forward as 2025.1.0 without issue. We can't go earlier because we need Remix v2 but I think we can go back that far.