### PR TITLE
Fix uneven deps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 1.4.2
+
+ - Fix Hydrogen mismatched deps
+
 ### 1.4.1
 
  - Allow older and newer versions of Hydrogen

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@redotech/redo-hydrogen",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@redotech/redo-hydrogen",
-      "version": "1.4.1",
+      "version": "1.4.2",
       "devDependencies": {
         "@rollup/plugin-commonjs": "^28.0.2",
         "@rollup/plugin-node-resolve": "^16.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redotech/redo-hydrogen",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Utilities to enable and disable Redo coverage on Hydrogen stores",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",


### PR DESCRIPTION
This is causing an issue for Made by Mary. These versions for Hydrogen and Hydrogen React shouldn't have ended up mismatched.